### PR TITLE
Security fix: add check to prevent path traversal attack

### DIFF
--- a/src/main/java/de/nrw/hbz/deepzoomer/serviceImpl/TilesService.java
+++ b/src/main/java/de/nrw/hbz/deepzoomer/serviceImpl/TilesService.java
@@ -16,15 +16,29 @@ import org.apache.log4j.Logger;
 @Path("/tiles")
 public class TilesService {
 	private static Logger log = Logger.getLogger(TilesService.class);
+
 	@GET
 	@Path("{path : .+}")
 	@Produces("image/jpeg")
 	public Response get(@PathParam("path") String path) {
 		try {
-			java.nio.file.Path p = Paths.get(Configuration.properties.getProperty("tilesDir") + File.separator + path);
-			return Response.ok(Files.readAllBytes(p)).header("content-type", "image/jpeg").build();
+			java.nio.file.Path tilesDir = Paths.get(Configuration.properties.getProperty("tilesDir"));
+			java.nio.file.Path p = Paths.get(tilesDir + File.separator + path);
+			if (isChild(p, tilesDir)) {
+				return Response.ok(Files.readAllBytes(p)).header("content-type", "image/jpeg").build();
+			}
+			log.warn("Forbidden path traversal. {IP} tries to access location outside "+tilesDir+".");
 		} catch (IOException e) {
-			return Response.status(406).build();
+			log.warn("", e);
+		}
+		return Response.status(406).build();
+	}
+
+	public static boolean isChild(java.nio.file.Path maybeChild, java.nio.file.Path possibleParent) {
+		try {
+			return maybeChild.toFile().getCanonicalPath().startsWith(possibleParent.toFile().getCanonicalPath());
+		} catch (Exception e) {
+			return false;
 		}
 	}
 }

--- a/src/test/java/deepzoomer/TestTilesService.java
+++ b/src/test/java/deepzoomer/TestTilesService.java
@@ -1,0 +1,30 @@
+package deepzoomer;
+
+import java.io.File;
+import java.nio.file.Paths;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import de.nrw.hbz.deepzoomer.serviceImpl.Configuration;
+import de.nrw.hbz.deepzoomer.serviceImpl.TilesService;
+
+public class TestTilesService {
+
+	@Test
+	public void test_succeed() {
+		java.nio.file.Path tilesDir = Paths.get(Configuration.properties.getProperty("tilesDir"));
+		java.nio.file.Path p = Paths.get(tilesDir + File.separator + "0/0_0.jpeg");
+		System.out.println(tilesDir +" | "+p);
+		Assert.assertTrue(TilesService.isChild(p,tilesDir));
+	}
+	
+	@Test
+	public void test_mustFail() {
+		java.nio.file.Path tilesDir = Paths.get(Configuration.properties.getProperty("tilesDir"));
+		java.nio.file.Path p = Paths.get(tilesDir + File.separator + "../../../etc/passwd");
+		System.out.println(tilesDir +" | "+p);
+		Assert.assertFalse(TilesService.isChild(p,tilesDir));
+	}
+
+}

--- a/src/test/resources/conf/deepzoomer.cfg
+++ b/src/test/resources/conf/deepzoomer.cfg
@@ -1,6 +1,6 @@
 # config file for the hbz deepzoomer Service based on 
 # VIPS
-tempDir= 
-tilesDir= 
+tempDir = /tmp/deepzoom/Temp
+tilesDir = /tmp/deepzoom/tilesCache
 resultUrl= http://localhost:8080/deepzoom/tiles
 serviceUrl= http://localhost:8080/deepzoom


### PR DESCRIPTION
- the mustFail test tries to access a directory
outside of the tilesDir. This should not be allowed.